### PR TITLE
feat: 세션 생성 요청 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/likelion/mooding/auth/presentation/AuthController.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/AuthController.java
@@ -1,0 +1,23 @@
+package com.likelion.mooding.auth.presentation;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    @PostMapping("/session")
+    public ResponseEntity<Void> createSession(final HttpServletRequest request) {
+        final HttpSession session = request.getSession(true);
+        if (session.isNew()) {
+            session.setAttribute("guestId", UUID.randomUUID());
+        }
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .build();
+    }
+}

--- a/src/test/java/com/likelion/mooding/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/likelion/mooding/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,76 @@
+package com.likelion.mooding.auth.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    void 사용자가_세션_생성을_요청하면_세션을_쿠키에_담아_응답한다() {
+        // given & when
+        final ExtractableResponse<Response> extract = RestAssured.given()
+                                                                 .log().all()
+                                                                 .when()
+                                                                 .post("/session")
+                                                                 .then()
+                                                                 .log().all()
+                                                                 .extract();
+
+        // then
+        final String actualSetCookie = extract.header("Set-Cookie");
+        final String actualSessionId = extract.sessionId();
+        final int actualStatusCode = extract.statusCode();
+
+        assertThat(actualSetCookie).isEqualTo("JSESSIONID=" + actualSessionId + "; Path=/; HttpOnly");
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 기존에_세션이_있던_사용자가_세션을_재요청하면_아무런_행동을_하지_않는다() {
+        // given
+        final ExtractableResponse<Response> extract = RestAssured.given()
+                                                                 .log().all()
+                                                                 .when()
+                                                                 .post("/session")
+                                                                 .then()
+                                                                 .log().all()
+                                                                 .extract();
+
+        // when
+        final ExtractableResponse<Response> secondExtract = RestAssured.given()
+                                                                       .sessionId(extract.sessionId())
+                                                                       .log().all()
+                                                                       .when()
+                                                                       .post("/session")
+                                                                       .then()
+                                                                       .log().all()
+                                                                       .extract();
+
+        final String actualSetCookie = secondExtract.header("Set-Cookie");
+
+        // then
+        // TODO: 자세한 세션 유효기간 검증 필요
+        assertThat(actualSetCookie).isNull();
+    }
+}


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #4 

## 🛠️작업 내용
사용자가 처음 서비스 진입 시에, 사용자를 식별할 수 있는 세션을 발급할 수 있는 API를 구현했습니다.

## 🤷‍♂️PR이 필요한 이유
사용자 식별을 통한 추후 인증/인가 로직 구현을 위해 필요합니다.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
