### PR TITLE
feat: 세션을 소유한 사용자에 대한 인증/인가 처리 구현

### DIFF
--- a/src/main/java/com/likelion/mooding/auth/annotation/Auth.java
+++ b/src/main/java/com/likelion/mooding/auth/annotation/Auth.java
@@ -1,0 +1,11 @@
+package com.likelion.mooding.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/com/likelion/mooding/auth/exception/SessionNotFoundException.java
+++ b/src/main/java/com/likelion/mooding/auth/exception/SessionNotFoundException.java
@@ -1,0 +1,8 @@
+package com.likelion.mooding.auth.exception;
+
+public class SessionNotFoundException extends RuntimeException {
+
+    public SessionNotFoundException() {
+        super("세션이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/likelion/mooding/auth/exception/SessionTimeoutException.java
+++ b/src/main/java/com/likelion/mooding/auth/exception/SessionTimeoutException.java
@@ -1,0 +1,8 @@
+package com.likelion.mooding.auth.exception;
+
+public class SessionTimeoutException extends RuntimeException {
+
+    public SessionTimeoutException() {
+        super("세션이 만료되었습니다.");
+    }
+}

--- a/src/main/java/com/likelion/mooding/auth/presentation/argumentresolver/GuestArgumentResolver.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/argumentresolver/GuestArgumentResolver.java
@@ -1,0 +1,38 @@
+package com.likelion.mooding.auth.presentation.argumentresolver;
+
+import com.likelion.mooding.auth.annotation.Auth;
+import com.likelion.mooding.auth.exception.SessionTimeoutException;
+import com.likelion.mooding.auth.presentation.dto.Guest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class GuestArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class) && parameter.getParameterType().equals(Guest.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter,
+                                  final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest,
+                                  final WebDataBinderFactory binderFactory)
+            throws Exception {
+        final HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        final HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            throw new SessionTimeoutException();
+        }
+
+        final String uuid = (String) session.getAttribute("guestId");
+        return new Guest(uuid);
+    }
+}

--- a/src/main/java/com/likelion/mooding/auth/presentation/dto/Guest.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/dto/Guest.java
@@ -1,0 +1,5 @@
+package com.likelion.mooding.auth.presentation.dto;
+
+public record Guest(String uuid) {
+
+}

--- a/src/main/java/com/likelion/mooding/auth/presentation/interceptor/GuestInterceptor.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/interceptor/GuestInterceptor.java
@@ -1,0 +1,21 @@
+package com.likelion.mooding.auth.presentation.interceptor;
+
+import com.likelion.mooding.auth.exception.SessionNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class GuestInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request,
+                             final HttpServletResponse response,
+                             final Object handler) throws Exception {
+        final HttpSession httpSession = request.getSession(false);
+        if (httpSession == null) { // 세션 ID가 아예 없거나 잘못된 세션 ID로 요청했을 때
+            throw new SessionNotFoundException();
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/likelion/mooding/common/config/WebConfig.java
+++ b/src/main/java/com/likelion/mooding/common/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.likelion.mooding.common.config;
+
+import com.likelion.mooding.auth.presentation.argumentresolver.GuestArgumentResolver;
+import com.likelion.mooding.auth.presentation.interceptor.GuestInterceptor;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new GuestArgumentResolver());
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(new GuestInterceptor())
+                .addPathPatterns("/feedback/**");
+    }
+}

--- a/src/main/java/com/likelion/mooding/common/exception/ExceptionResponse.java
+++ b/src/main/java/com/likelion/mooding/common/exception/ExceptionResponse.java
@@ -1,0 +1,5 @@
+package com.likelion.mooding.common.exception;
+
+public record ExceptionResponse(String message) {
+
+}

--- a/src/main/java/com/likelion/mooding/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/likelion/mooding/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.likelion.mooding.common.exception;
+
+import com.likelion.mooding.auth.exception.SessionNotFoundException;
+import com.likelion.mooding.auth.exception.SessionTimeoutException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({
+            SessionNotFoundException.class,
+            SessionTimeoutException.class})
+    public ResponseEntity<ExceptionResponse> handleSessionNotFoundException(final SessionNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                             .body(new ExceptionResponse(exception.getMessage()));
+    }
+}


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #12 

## 🛠️작업 내용
- [x] 게스트 멤버의 인증을 위한 인터셉터 구현
- [x] 게스트 멤버의 인가를 위한 ArgumentResolver 구현

## 🤷‍♂️PR이 필요한 이유
추후 구현할 API에는, 게스트 사용자에 대해 인증/인가 로직이 필요하기 때문에, 이를 위해 interceptor와 argument resolver를 구현하였습니다.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
