### PR TITLE
feat: 피드백 생성 요청 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/likelion/mooding/auth/presentation/argumentresolver/GuestArgumentResolver.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/argumentresolver/GuestArgumentResolver.java
@@ -32,7 +32,7 @@ public class GuestArgumentResolver implements HandlerMethodArgumentResolver {
             throw new SessionTimeoutException();
         }
 
-        final String uuid = (String) session.getAttribute("guestId");
+        final String uuid = session.getAttribute("guestId").toString();
         return new Guest(uuid);
     }
 }

--- a/src/main/java/com/likelion/mooding/auth/presentation/dto/Guest.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/dto/Guest.java
@@ -1,5 +1,8 @@
 package com.likelion.mooding.auth.presentation.dto;
 
-public record Guest(String uuid) {
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record Guest(String guestId) {
 
 }

--- a/src/main/java/com/likelion/mooding/feedback/application/FeedbackChatCompletionService.java
+++ b/src/main/java/com/likelion/mooding/feedback/application/FeedbackChatCompletionService.java
@@ -1,0 +1,10 @@
+package com.likelion.mooding.feedback.application;
+
+import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import reactor.core.publisher.Mono;
+
+public interface FeedbackChatCompletionService {
+
+    Mono<FeedbackCreateResponse> completeChat(final FeedbackCreateRequest request);
+}

--- a/src/main/java/com/likelion/mooding/feedback/application/FeedbackService.java
+++ b/src/main/java/com/likelion/mooding/feedback/application/FeedbackService.java
@@ -1,0 +1,38 @@
+package com.likelion.mooding.feedback.application;
+
+import com.likelion.mooding.auth.presentation.dto.Guest;
+import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
+import com.likelion.mooding.feedback.domain.Feedback;
+import com.likelion.mooding.feedback.domain.FeedbackRepository;
+import com.likelion.mooding.feedback.domain.FeedbackStatus;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+@Service
+@Transactional
+public class FeedbackService {
+
+    private final FeedbackChatCompletionService feedbackChatCompletionService;
+
+    private final FeedbackRepository feedbackRepository;
+
+    public FeedbackService(final FeedbackChatCompletionService feedbackChatCompletionService,
+                           final FeedbackRepository feedbackRepository) {
+        this.feedbackChatCompletionService = feedbackChatCompletionService;
+        this.feedbackRepository = feedbackRepository;
+    }
+
+    public Long createFeedback(final Guest guest,
+                               final FeedbackCreateRequest request) {
+        final Feedback feedback = new Feedback(FeedbackStatus.IN_PROGRESS, "", guest);
+        feedbackRepository.save(feedback);
+
+        final Mono<FeedbackCreateResponse> mono = feedbackChatCompletionService.completeChat(request);
+        mono.subscribe(response -> feedbackRepository.updateFeedbackStatusAndContentById(feedback.getId(),
+                                                                                         FeedbackStatus.DONE,
+                                                                                         response.feedback()));
+        return feedback.getId();
+    }
+}

--- a/src/main/java/com/likelion/mooding/feedback/application/dto/FeedbackCreateResponse.java
+++ b/src/main/java/com/likelion/mooding/feedback/application/dto/FeedbackCreateResponse.java
@@ -1,0 +1,4 @@
+package com.likelion.mooding.feedback.application.dto;
+
+public record FeedbackCreateResponse(String feedback) {
+}

--- a/src/main/java/com/likelion/mooding/feedback/domain/Feedback.java
+++ b/src/main/java/com/likelion/mooding/feedback/domain/Feedback.java
@@ -1,0 +1,61 @@
+package com.likelion.mooding.feedback.domain;
+
+import com.likelion.mooding.auth.presentation.dto.Guest;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Feedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(value = EnumType.STRING)
+    private FeedbackStatus feedbackStatus;
+
+    private String content;
+
+    @Embedded
+    private Guest guest;
+
+    public Feedback(final Long id,
+                    final FeedbackStatus feedbackStatus,
+                    final String content,
+                    final Guest guest) {
+        this.id = id;
+        this.feedbackStatus = feedbackStatus;
+        this.content = content;
+        this.guest = guest;
+    }
+
+    public Feedback(final FeedbackStatus feedbackStatus,
+                    final String content,
+                    final Guest guest) {
+        this(null, feedbackStatus, content, guest);
+    }
+
+    protected Feedback() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public FeedbackStatus getFeedbackStatus() {
+        return feedbackStatus;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Guest getGuest() {
+        return guest;
+    }
+}

--- a/src/main/java/com/likelion/mooding/feedback/domain/FeedbackRepository.java
+++ b/src/main/java/com/likelion/mooding/feedback/domain/FeedbackRepository.java
@@ -1,0 +1,14 @@
+package com.likelion.mooding.feedback.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Feedback f SET f.feedbackStatus = :feedbackStatus, f.content = :content WHERE f.id = :id")
+    void updateFeedbackStatusAndContentById(final Long id, final FeedbackStatus feedbackStatus, final String content);
+}

--- a/src/main/java/com/likelion/mooding/feedback/domain/FeedbackStatus.java
+++ b/src/main/java/com/likelion/mooding/feedback/domain/FeedbackStatus.java
@@ -1,0 +1,9 @@
+package com.likelion.mooding.feedback.domain;
+
+public enum FeedbackStatus {
+
+    IN_PROGRESS,
+
+    DONE,
+    ;
+}

--- a/src/main/java/com/likelion/mooding/feedback/presentation/FeedbackController.java
+++ b/src/main/java/com/likelion/mooding/feedback/presentation/FeedbackController.java
@@ -1,0 +1,33 @@
+package com.likelion.mooding.feedback.presentation;
+
+import com.likelion.mooding.auth.annotation.Auth;
+import com.likelion.mooding.auth.presentation.dto.Guest;
+import com.likelion.mooding.feedback.application.FeedbackService;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import java.net.URI;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/feedback")
+public class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    public FeedbackController(final FeedbackService feedbackService) {
+        this.feedbackService = feedbackService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createFeedback(@Auth final Guest guest,
+                                               @RequestBody final FeedbackCreateRequest request) {
+        final Long id = feedbackService.createFeedback(guest, request);
+        return ResponseEntity.status(HttpStatus.OK)
+                             .location(URI.create("/feedback/status/" + id))
+                             .build();
+    }
+}

--- a/src/main/java/com/likelion/mooding/feedback/presentation/dto/FeedbackCreateRequest.java
+++ b/src/main/java/com/likelion/mooding/feedback/presentation/dto/FeedbackCreateRequest.java
@@ -1,0 +1,4 @@
+package com.likelion.mooding.feedback.presentation.dto;
+
+public record FeedbackCreateRequest(String diaryContent) {
+}

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/application/OpenAIFeedbackChatCompletionService.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/application/OpenAIFeedbackChatCompletionService.java
@@ -1,0 +1,35 @@
+package com.likelion.mooding.infrastructure.openai.application;
+
+import com.likelion.mooding.feedback.application.FeedbackChatCompletionService;
+import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import com.likelion.mooding.infrastructure.openai.dto.ChatCompletionCreateRequest;
+import com.likelion.mooding.infrastructure.openai.dto.ChatCompletionCreateResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class OpenAIFeedbackChatCompletionService implements FeedbackChatCompletionService {
+
+    private final WebClient webClient;
+
+    public OpenAIFeedbackChatCompletionService(final WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    @Override
+    public Mono<FeedbackCreateResponse> completeChat(final FeedbackCreateRequest request) {
+        final Mono<ChatCompletionCreateResponse> mono = webClient.post()
+                                                                 .accept(MediaType.APPLICATION_JSON)
+                                                                 .bodyValue(ChatCompletionCreateRequest.from(request.diaryContent()))
+                                                                 .retrieve()
+                                                                 .bodyToMono(ChatCompletionCreateResponse.class);
+
+        return mono.flatMap(response -> {
+            final String feedback = response.getMessageContent();
+            return Mono.just(new FeedbackCreateResponse(feedback));
+        });
+    }
+}

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/config/OpenAIConfig.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/config/OpenAIConfig.java
@@ -1,0 +1,26 @@
+package com.likelion.mooding.infrastructure.openai.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class OpenAIConfig {
+
+    // TODO: OpenAI API Key 숨기기
+//    @Value("${openai.api.key}")
+    private final String OPENAI_API_KEY = "";
+
+    @Bean
+    public WebClient openAIClient() {
+        return WebClient
+                .builder()
+                .baseUrl("https://api.openai.com/v1/chat/completions")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, String.valueOf(MediaType.APPLICATION_JSON))
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + OPENAI_API_KEY)
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/config/OpenAIConfig.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/config/OpenAIConfig.java
@@ -10,9 +10,11 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class OpenAIConfig {
 
-    // TODO: OpenAI API Key 숨기기
-//    @Value("${openai.api.key}")
-    private final String OPENAI_API_KEY = "";
+    private final String OPENAI_API_KEY;
+
+    public OpenAIConfig(@Value("${openai.api.key}") final String OPENAI_API_KEY) {
+        this.OPENAI_API_KEY = OPENAI_API_KEY;
+    }
 
     @Bean
     public WebClient openAIClient() {

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/constant/ChatCompletionRole.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/constant/ChatCompletionRole.java
@@ -1,0 +1,20 @@
+package com.likelion.mooding.infrastructure.openai.constant;
+
+public enum ChatCompletionRole {
+
+    SYSTEM("system"),
+
+    USER("user"),
+
+    ASSISTANT("assistant");
+
+    private final String role;
+
+    ChatCompletionRole(final String role) {
+        this.role = role;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionChoice.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionChoice.java
@@ -1,0 +1,4 @@
+package com.likelion.mooding.infrastructure.openai.dto;
+
+public record ChatCompletionChoice(ChatCompletionMessage message) {
+}

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionCreateRequest.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionCreateRequest.java
@@ -10,11 +10,20 @@ public record ChatCompletionCreateRequest(
 
     public static ChatCompletionCreateRequest from(final String userContent) {
         return new ChatCompletionCreateRequest(
-                "gpt-3.5-turbo",
+                "gpt-4o-mini",
                 List.of(
-                        // TODO: system, user, assistant 추가
                         new ChatCompletionMessage(ChatCompletionRole.SYSTEM.getRole(),
-                                                  "너는 이름은 무딩이야. 사용자가 너에게 감정일기를 제공할텐데, 너는 이 일기 내용을 그저 공감해주면 돼. 이유는 절대로 묻지마. 최대한 따뜻한 어조를 사용해서 답변해줘."),
+                                                  "You're a character that eats and digests the user's emotional diary, so you need to empathise with their feelings and say something kind. Don't offer solutions, but respond in a friendly, friendly way. Your response should help relieve the user's mental stress. If they're happy, celebrate with them, and if they need a compliment, give them one. If they're sad, empathise with them and let them know that you've eaten all things of user's bad feelings and will get over it since you've eaten. You must answer in Korean."),
+
+                        new ChatCompletionMessage(ChatCompletionRole.USER.getRole(),
+                                                  "오늘 OpenAI API를 연동하는 작업을 예상보다 빠르게 끝낼 수 있어서 속이 후련하고 기분이 좋았어! 중간에 에러가 발생해서 답답하고 힘들었지만 그래도 문제를 해결하게 되어서 뿌듯했어."),
+                        new ChatCompletionMessage(ChatCompletionRole.ASSISTANT.getRole(),
+                                                  "와, 어려운 일이었을텐데 척척 잘 해결하셨다니 너무 대단한데요? 예상보다 빠르게 작업을 끝내고 뿌듯한 기분이 들었을 거예요. 에러로 인해 힘들었던 순간도 있었겠지만, 그런 어려움을 해결하고 나니 더욱 강해진 거죠. 다음에 더 즐거운 감정일기로 만났으면 좋겠어요!"),
+                        new ChatCompletionMessage(ChatCompletionRole.USER.getRole(),
+                                                  "오늘 중간고사를 봤는데 내가 공부한 내용이 하나도 나오지 않아서 완전 망했어. 밤도 새면서 최대한 할 수 있는만큼 했는데 하늘이 날 돕지 않았나봐. 너무 짜증나고 아무것도 하기 싫어."),
+                        new ChatCompletionMessage(ChatCompletionRole.ASSISTANT.getRole(),
+                                                  "슬픔과 좌절이 느껴지는데, 그런 기분 이해해요. 중간고사가 마음대로 되지 않아서 분명 실망스러웠을 거예요. 그렇지만 이렇게 힘들었던 하루를 잘 이겨내고 있다니 정말 대단해요. 시험 성적이 잘 나오지 않은 것 같아서 너무 속상하겠지만, 이 모든 감정들을 제가 다 먹어버렸어요. 그러니 곧 괜찮아질 거예요. 마음이 편해지길 바래요. 함께 이겨내요!"),
+
                         new ChatCompletionMessage(ChatCompletionRole.USER.getRole(), userContent)
                        )
         );

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionCreateRequest.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionCreateRequest.java
@@ -1,0 +1,22 @@
+package com.likelion.mooding.infrastructure.openai.dto;
+
+import com.likelion.mooding.infrastructure.openai.constant.ChatCompletionRole;
+import java.util.List;
+
+public record ChatCompletionCreateRequest(
+        String model,
+        List<ChatCompletionMessage> messages
+) {
+
+    public static ChatCompletionCreateRequest from(final String userContent) {
+        return new ChatCompletionCreateRequest(
+                "gpt-3.5-turbo",
+                List.of(
+                        // TODO: system, user, assistant 추가
+                        new ChatCompletionMessage(ChatCompletionRole.SYSTEM.getRole(),
+                                                  "너는 이름은 무딩이야. 사용자가 너에게 감정일기를 제공할텐데, 너는 이 일기 내용을 그저 공감해주면 돼. 이유는 절대로 묻지마. 최대한 따뜻한 어조를 사용해서 답변해줘."),
+                        new ChatCompletionMessage(ChatCompletionRole.USER.getRole(), userContent)
+                       )
+        );
+    }
+}

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionCreateResponse.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionCreateResponse.java
@@ -1,0 +1,12 @@
+package com.likelion.mooding.infrastructure.openai.dto;
+
+import java.util.List;
+
+public record ChatCompletionCreateResponse(List<ChatCompletionChoice> choices) {
+
+    public String getMessageContent() {
+        return choices.get(0)
+                      .message()
+                      .content();
+    }
+}

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionMessage.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionMessage.java
@@ -1,0 +1,9 @@
+package com.likelion.mooding.infrastructure.openai.dto;
+
+import com.likelion.mooding.infrastructure.openai.constant.ChatCompletionRole;
+
+public record ChatCompletionMessage(
+        String role,
+        String content
+) {
+}

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionMessage.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionMessage.java
@@ -1,7 +1,5 @@
 package com.likelion.mooding.infrastructure.openai.dto;
 
-import com.likelion.mooding.infrastructure.openai.constant.ChatCompletionRole;
-
 public record ChatCompletionMessage(
         String role,
         String content

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=mooding

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,3 +25,7 @@ logging:
           descriptor:
             sql:
               BasicBinder: TRACE
+
+openai:
+  api:
+    key: ${OPENAI_API_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,27 @@
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+spring:
+  h2:
+    console:
+      enabled: 'true'
+  datasource:
+    username: sa
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+  jpa:
+    properties:
+      hibernate:
+        format_sql: 'true'
+    defer-datasource-initialization: 'true'
+    show-sql: 'true'
+    hibernate:
+      ddl-auto: create-drop
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql:
+              BasicBinder: TRACE

--- a/src/test/java/com/likelion/mooding/feedback/application/FeedbackServiceTest.java
+++ b/src/test/java/com/likelion/mooding/feedback/application/FeedbackServiceTest.java
@@ -1,0 +1,55 @@
+package com.likelion.mooding.feedback.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.likelion.mooding.auth.presentation.dto.Guest;
+import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
+import com.likelion.mooding.feedback.domain.FeedbackRepository;
+import com.likelion.mooding.feedback.domain.FeedbackStatus;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import reactor.core.publisher.Mono;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest
+class FeedbackServiceTest {
+
+    @MockBean
+    private FeedbackChatCompletionService feedbackChatCompletionService;
+
+    @Autowired
+    private FeedbackRepository feedbackRepository;
+
+    @Autowired
+    private FeedbackService feedbackService;
+
+    @Test
+    void 감정일기에_대한_피드백_생성이_완료되면_DB_에_값을_업데이트한다() throws InterruptedException {
+        // given
+        final FeedbackCreateRequest request = new FeedbackCreateRequest("TEST_CONTENT");
+
+        given(feedbackChatCompletionService.completeChat(request))
+                .willReturn(Mono.just(new FeedbackCreateResponse("TEST_FEEDBACK")).delayElement(Duration.ofSeconds(2)));
+
+        // when
+        final Long feedbackId = feedbackService.createFeedback(new Guest("id"), request);
+
+        // TODO: Thread.sleep 대신 테스트 가능한 방법 찾기
+        Thread.sleep(3000);
+
+        // then
+        feedbackRepository.findById(feedbackId)
+                          .ifPresent(feedback -> {
+                              assertThat(feedback.getFeedbackStatus()).isEqualTo(FeedbackStatus.DONE);
+                              assertThat(feedback.getContent()).isEqualTo("TEST_FEEDBACK");
+                          });
+    }
+}

--- a/src/test/java/com/likelion/mooding/feedback/presentation/FeedbackControllerTest.java
+++ b/src/test/java/com/likelion/mooding/feedback/presentation/FeedbackControllerTest.java
@@ -1,0 +1,75 @@
+package com.likelion.mooding.feedback.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.likelion.mooding.feedback.application.FeedbackChatCompletionService;
+import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import reactor.core.publisher.Mono;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class FeedbackControllerTest {
+
+    @MockBean
+    private FeedbackChatCompletionService feedbackChatCompletionService;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @BeforeEach
+    void mockFeedbackChatCompletionService() {
+        given(feedbackChatCompletionService.completeChat(any()))
+                .willReturn(Mono.just(new FeedbackCreateResponse("TEST_FEEDBACK")).delayElement(Duration.ofSeconds(1)));
+    }
+
+    @Test
+    void 사용자가_피드백_생성_요청을_하면_피드백_ID_를_응답한다() {
+        // given
+        final ExtractableResponse<Response> extract = RestAssured.given()
+                                                                 .log().all()
+                                                                 .when()
+                                                                 .post("/session")
+                                                                 .then()
+                                                                 .log().all()
+                                                                 .extract();
+        FeedbackCreateRequest request = new FeedbackCreateRequest("TEST_CONTENT");
+
+        // when
+        final ExtractableResponse<Response> actualExtract = RestAssured.given()
+                                                                       .sessionId(extract.sessionId())
+                                                                       .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                                                       .body(request)
+                                                                       .log().all()
+                                                                       .when()
+                                                                       .post("/feedback")
+                                                                       .then()
+                                                                       .log().all()
+                                                                       .extract();
+
+        // then
+        assertThat(actualExtract.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(actualExtract.header("Location")).isEqualTo("/feedback/status/" + 1L);
+    }
+}


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #6 

## 🛠️작업 내용
- [x] GPT API 비동기 처리 구현
- [x] 비즈니스 도메인과 외부 의존성 격리
- [x] API 문서 스펙에 맞게 요청/응답 구성

## 🤷‍♂️PR이 필요한 이유
사용자의 감정일기에 대한 피드백 생성을 요청하기 위해 API를 구현했습니다.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
