### PR TITLE
feat: 피드백 생성 진행상태 요청 API 구현

### DIFF
--- a/src/main/java/com/likelion/mooding/auth/presentation/dto/Guest.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/dto/Guest.java
@@ -1,8 +1,8 @@
 package com.likelion.mooding.auth.presentation.dto;
 
 import jakarta.persistence.Embeddable;
+import java.util.Objects;
 
 @Embeddable
 public record Guest(String guestId) {
-
 }

--- a/src/main/java/com/likelion/mooding/feedback/application/FeedbackService.java
+++ b/src/main/java/com/likelion/mooding/feedback/application/FeedbackService.java
@@ -5,7 +5,9 @@ import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
 import com.likelion.mooding.feedback.domain.Feedback;
 import com.likelion.mooding.feedback.domain.FeedbackRepository;
 import com.likelion.mooding.feedback.domain.FeedbackStatus;
+import com.likelion.mooding.feedback.exception.FeedbackAuthException;
 import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackStatusResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
@@ -34,5 +36,14 @@ public class FeedbackService {
                                                                                          FeedbackStatus.DONE,
                                                                                          response.feedback()));
         return feedback.getId();
+    }
+
+    public FeedbackStatusResponse getFeedbackStatus(final Guest guest,
+                                                    final Long id) {
+        final Feedback feedback = feedbackRepository.findByIdOrThrow(id);
+        if (!feedback.isOwner(guest)) {
+            throw new FeedbackAuthException();
+        }
+        return new FeedbackStatusResponse(feedback.getFeedbackStatus().name());
     }
 }

--- a/src/main/java/com/likelion/mooding/feedback/domain/Feedback.java
+++ b/src/main/java/com/likelion/mooding/feedback/domain/Feedback.java
@@ -43,6 +43,10 @@ public class Feedback {
     protected Feedback() {
     }
 
+    public boolean isOwner(final Guest other) {
+        return this.guest.equals(other);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/likelion/mooding/feedback/domain/FeedbackRepository.java
+++ b/src/main/java/com/likelion/mooding/feedback/domain/FeedbackRepository.java
@@ -7,6 +7,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
+    default Feedback findByIdOrThrow(final Long id) {
+        return findById(id).orElseThrow(() -> new IllegalArgumentException("Invalid feedback id"));
+    }
+
     @Transactional
     @Modifying
     @Query("UPDATE Feedback f SET f.feedbackStatus = :feedbackStatus, f.content = :content WHERE f.id = :id")

--- a/src/main/java/com/likelion/mooding/feedback/exception/FeedbackAuthException.java
+++ b/src/main/java/com/likelion/mooding/feedback/exception/FeedbackAuthException.java
@@ -1,0 +1,8 @@
+package com.likelion.mooding.feedback.exception;
+
+public class FeedbackAuthException extends RuntimeException {
+
+    public FeedbackAuthException() {
+        super("Feedback auth failed");
+    }
+}

--- a/src/main/java/com/likelion/mooding/feedback/exception/FeedbackNotFoundException.java
+++ b/src/main/java/com/likelion/mooding/feedback/exception/FeedbackNotFoundException.java
@@ -1,0 +1,8 @@
+package com.likelion.mooding.feedback.exception;
+
+public class FeedbackNotFoundException extends RuntimeException {
+
+    public FeedbackNotFoundException() {
+        super("Feedback not found");
+    }
+}

--- a/src/main/java/com/likelion/mooding/feedback/presentation/FeedbackController.java
+++ b/src/main/java/com/likelion/mooding/feedback/presentation/FeedbackController.java
@@ -4,9 +4,12 @@ import com.likelion.mooding.auth.annotation.Auth;
 import com.likelion.mooding.auth.presentation.dto.Guest;
 import com.likelion.mooding.feedback.application.FeedbackService;
 import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackStatusResponse;
 import java.net.URI;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +32,13 @@ public class FeedbackController {
         return ResponseEntity.status(HttpStatus.OK)
                              .location(URI.create("/feedback/status/" + id))
                              .build();
+    }
+
+    @GetMapping("/status/{id}")
+    public ResponseEntity<FeedbackStatusResponse> getFeedbackStatus(@Auth final Guest guest,
+                                                                    @PathVariable final Long id) {
+        final FeedbackStatusResponse response = feedbackService.getFeedbackStatus(guest, id);
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                             .body(response);
     }
 }

--- a/src/main/java/com/likelion/mooding/feedback/presentation/dto/FeedbackStatusResponse.java
+++ b/src/main/java/com/likelion/mooding/feedback/presentation/dto/FeedbackStatusResponse.java
@@ -1,0 +1,4 @@
+package com.likelion.mooding.feedback.presentation.dto;
+
+public record FeedbackStatusResponse (String status) {
+}

--- a/src/test/java/com/likelion/mooding/e2e/E2EClient.java
+++ b/src/test/java/com/likelion/mooding/e2e/E2EClient.java
@@ -1,0 +1,51 @@
+package com.likelion.mooding.e2e;
+
+import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.springframework.http.MediaType;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+public class E2EClient {
+
+    public static ExtractableResponse<Response> 세션_요청() {
+        return RestAssured.given()
+                          .log().all()
+                          .when()
+                          .post("/session")
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    public static ExtractableResponse<Response> 피드백_생성_요청(final String sessionId,
+                                                          final FeedbackCreateRequest request) {
+        return RestAssured.given()
+                          .sessionId(sessionId)
+                          .contentType(MediaType.APPLICATION_JSON_VALUE)
+                          .body(request)
+                          .log().all()
+                          .when()
+                          .post("/feedback")
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+
+    public static ExtractableResponse<Response> 피드백_진행상태_요청(final String sessionId,
+                                                            final Long id) {
+        return RestAssured.given()
+                          .sessionId(sessionId)
+                          .contentType(MediaType.APPLICATION_JSON_VALUE)
+                          .log().all()
+                          .when()
+                          .get("/feedback/status/{id}", id)
+                          .then()
+                          .log().all()
+                          .extract();
+    }
+}

--- a/src/test/java/com/likelion/mooding/feedback/application/FeedbackServiceTest.java
+++ b/src/test/java/com/likelion/mooding/feedback/application/FeedbackServiceTest.java
@@ -1,16 +1,21 @@
 package com.likelion.mooding.feedback.application;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.likelion.mooding.auth.presentation.dto.Guest;
 import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
+import com.likelion.mooding.feedback.domain.Feedback;
 import com.likelion.mooding.feedback.domain.FeedbackRepository;
 import com.likelion.mooding.feedback.domain.FeedbackStatus;
+import com.likelion.mooding.feedback.exception.FeedbackAuthException;
 import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackStatusResponse;
 import java.time.Duration;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,13 +42,13 @@ class FeedbackServiceTest {
         final FeedbackCreateRequest request = new FeedbackCreateRequest("TEST_CONTENT");
 
         given(feedbackChatCompletionService.completeChat(request))
-                .willReturn(Mono.just(new FeedbackCreateResponse("TEST_FEEDBACK")).delayElement(Duration.ofSeconds(2)));
+                .willReturn(Mono.just(new FeedbackCreateResponse("TEST_FEEDBACK")).delayElement(Duration.ofSeconds(1)));
 
         // when
         final Long feedbackId = feedbackService.createFeedback(new Guest("id"), request);
 
         // TODO: Thread.sleep 대신 테스트 가능한 방법 찾기
-        Thread.sleep(3000);
+        Thread.sleep(2000);
 
         // then
         feedbackRepository.findById(feedbackId)
@@ -51,5 +56,42 @@ class FeedbackServiceTest {
                               assertThat(feedback.getFeedbackStatus()).isEqualTo(FeedbackStatus.DONE);
                               assertThat(feedback.getContent()).isEqualTo("TEST_FEEDBACK");
                           });
+    }
+
+    @Nested
+    class 특정_피드백의_진행상태를_요청할_때 {
+
+        final String guestId = "owner_id";
+        final String otherId = "other_id";
+
+        @Test
+        void 본인의_피드백이라면_진행상태를_응답한다() {
+            // given
+            final Feedback feedback = new Feedback(FeedbackStatus.IN_PROGRESS,
+                                                   "TEST_CONTENT",
+                                                   new Guest(guestId));
+            feedbackRepository.save(feedback);
+
+            // when
+            final FeedbackStatusResponse actual = feedbackService.getFeedbackStatus(new Guest(guestId),
+                                                                                    feedback.getId());
+
+            // then
+            final FeedbackStatusResponse expected = new FeedbackStatusResponse(FeedbackStatus.IN_PROGRESS.name());
+            assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+        }
+
+        @Test
+        void 본인의_피드백이_아니라면_인가_에러가_발생한다() {
+            // given
+            final Feedback feedback = new Feedback(FeedbackStatus.IN_PROGRESS,
+                                                   "TEST_CONTENT",
+                                                   new Guest(guestId));
+            feedbackRepository.save(feedback);
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.getFeedbackStatus(new Guest(otherId), feedback.getId()))
+                    .isInstanceOf(FeedbackAuthException.class);
+        }
     }
 }

--- a/src/test/java/com/likelion/mooding/feedback/presentation/FeedbackControllerTest.java
+++ b/src/test/java/com/likelion/mooding/feedback/presentation/FeedbackControllerTest.java
@@ -1,5 +1,8 @@
 package com.likelion.mooding.feedback.presentation;
 
+import static com.likelion.mooding.e2e.E2EClient.세션_요청;
+import static com.likelion.mooding.e2e.E2EClient.피드백_생성_요청;
+import static com.likelion.mooding.e2e.E2EClient.피드백_진행상태_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -7,6 +10,7 @@ import static org.mockito.BDDMockito.given;
 import com.likelion.mooding.feedback.application.FeedbackChatCompletionService;
 import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
 import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackStatusResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -14,12 +18,12 @@ import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import reactor.core.publisher.Mono;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -38,38 +42,74 @@ class FeedbackControllerTest {
         RestAssured.port = port;
     }
 
+    // TODO: Mono 딜레이 시간을 테스트에 따라 조절할 수 있도록 변경
     @BeforeEach
     void mockFeedbackChatCompletionService() {
         given(feedbackChatCompletionService.completeChat(any()))
-                .willReturn(Mono.just(new FeedbackCreateResponse("TEST_FEEDBACK")).delayElement(Duration.ofSeconds(1)));
+                .willReturn(Mono.just(new FeedbackCreateResponse("TEST_FEEDBACK")).delayElement(Duration.ofSeconds(2)));
     }
 
     @Test
     void 사용자가_피드백_생성_요청을_하면_피드백_ID_를_응답한다() {
         // given
-        final ExtractableResponse<Response> extract = RestAssured.given()
-                                                                 .log().all()
-                                                                 .when()
-                                                                 .post("/session")
-                                                                 .then()
-                                                                 .log().all()
-                                                                 .extract();
+        final ExtractableResponse<Response> sessionResponse = 세션_요청();
+
         FeedbackCreateRequest request = new FeedbackCreateRequest("TEST_CONTENT");
 
         // when
-        final ExtractableResponse<Response> actualExtract = RestAssured.given()
-                                                                       .sessionId(extract.sessionId())
-                                                                       .contentType(MediaType.APPLICATION_JSON_VALUE)
-                                                                       .body(request)
-                                                                       .log().all()
-                                                                       .when()
-                                                                       .post("/feedback")
-                                                                       .then()
-                                                                       .log().all()
-                                                                       .extract();
+        final ExtractableResponse<Response> actualExtract = 피드백_생성_요청(sessionResponse.sessionId(), request);
 
         // then
+        final Long id = getIdFromLocationHeader(actualExtract.header("Location"));
+
         assertThat(actualExtract.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(actualExtract.header("Location")).isEqualTo("/feedback/status/" + 1L);
+        assertThat(actualExtract.header("Location")).isEqualTo("/feedback/status/" + id);
+    }
+
+    @Nested
+    class 사용자가_피드백_진행상태를_요청하면 {
+
+        @Test
+        void 피드백_생성이_완료되지_않았을_때_IN_PROGRESS_를_응답한다() {
+            // given
+            final ExtractableResponse<Response> sessionResponse = 세션_요청();
+
+            FeedbackCreateRequest request = new FeedbackCreateRequest("TEST_CONTENT");
+
+            final ExtractableResponse<Response> feedbackResponse = 피드백_생성_요청(sessionResponse.sessionId(), request);
+            final Long id = getIdFromLocationHeader(feedbackResponse.header("Location"));
+
+            // when
+            final ExtractableResponse<Response> statusResponse = 피드백_진행상태_요청(sessionResponse.sessionId(), id);
+
+            // then
+            final FeedbackStatusResponse actual = statusResponse.as(FeedbackStatusResponse.class);
+            assertThat(actual.status()).isEqualTo("IN_PROGRESS");
+        }
+
+        @Test
+        void 피드백_생성이_완료됐을_때_DONE_을_응답한다() throws InterruptedException {
+            // given
+            final ExtractableResponse<Response> sessionResponse = 세션_요청();
+
+            FeedbackCreateRequest request = new FeedbackCreateRequest("TEST_CONTENT");
+
+            final ExtractableResponse<Response> feedbackResponse = 피드백_생성_요청(sessionResponse.sessionId(), request);
+            final Long id = getIdFromLocationHeader(feedbackResponse.header("Location"));
+
+            Thread.sleep(2500);
+
+            // when
+            final ExtractableResponse<Response> statusResponse = 피드백_진행상태_요청(sessionResponse.sessionId(), id);
+
+            // then
+            final FeedbackStatusResponse actual = statusResponse.as(FeedbackStatusResponse.class);
+            assertThat(actual.status()).isEqualTo("DONE");
+        }
+    }
+
+    private Long getIdFromLocationHeader(final String location) {
+        final String[] split = location.split("/");
+        return Long.parseLong(split[split.length - 1]);
     }
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -28,4 +28,4 @@ logging:
 
 openai:
   api:
-    key: ${OPENAI_API_KEY}
+    key: 'fake-key'


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #10 

## 🛠️작업 내용
- [x] 사용자가 요청한 피드백의 ID로 DB에 쿼리를 날려 결과 값의 유무를 확인한다.
- [x] 결과 값에 따른 응답 상태를 응답한다.

## 🤷‍♂️PR이 필요한 이유
Polling 방식의 피드백 생성 진행상태를 알기 위해 해당 API 구현이 필요합니다.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
