### PR TITLE
feat: 피드백 단건 조회 API 구현

### DIFF
--- a/src/main/java/com/likelion/mooding/feedback/application/FeedbackService.java
+++ b/src/main/java/com/likelion/mooding/feedback/application/FeedbackService.java
@@ -7,6 +7,7 @@ import com.likelion.mooding.feedback.domain.FeedbackRepository;
 import com.likelion.mooding.feedback.domain.FeedbackStatus;
 import com.likelion.mooding.feedback.exception.FeedbackAuthException;
 import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackResultResponse;
 import com.likelion.mooding.feedback.presentation.dto.FeedbackStatusResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,5 +46,14 @@ public class FeedbackService {
             throw new FeedbackAuthException();
         }
         return new FeedbackStatusResponse(feedback.getFeedbackStatus().name());
+    }
+
+    public FeedbackResultResponse getFeedback(final Guest guest,
+                                              final Long id) {
+        final Feedback feedback = feedbackRepository.findByIdOrThrow(id);
+        if (!feedback.isOwner(guest)) {
+            throw new FeedbackAuthException();
+        }
+        return new FeedbackResultResponse(feedback.getContent());
     }
 }

--- a/src/main/java/com/likelion/mooding/feedback/presentation/FeedbackController.java
+++ b/src/main/java/com/likelion/mooding/feedback/presentation/FeedbackController.java
@@ -4,6 +4,7 @@ import com.likelion.mooding.auth.annotation.Auth;
 import com.likelion.mooding.auth.presentation.dto.Guest;
 import com.likelion.mooding.feedback.application.FeedbackService;
 import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackResultResponse;
 import com.likelion.mooding.feedback.presentation.dto.FeedbackStatusResponse;
 import java.net.URI;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,14 @@ public class FeedbackController {
         return ResponseEntity.status(HttpStatus.OK)
                              .location(URI.create("/feedback/status/" + id))
                              .build();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<FeedbackResultResponse> getFeedback(@Auth final Guest guest,
+                                                              @PathVariable final Long id) {
+        final FeedbackResultResponse response = feedbackService.getFeedback(guest, id);
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(response);
     }
 
     @GetMapping("/status/{id}")

--- a/src/main/java/com/likelion/mooding/feedback/presentation/dto/FeedbackResultResponse.java
+++ b/src/main/java/com/likelion/mooding/feedback/presentation/dto/FeedbackResultResponse.java
@@ -1,0 +1,4 @@
+package com.likelion.mooding.feedback.presentation.dto;
+
+public record FeedbackResultResponse(String result) {
+}

--- a/src/test/java/com/likelion/mooding/e2e/E2EClient.java
+++ b/src/test/java/com/likelion/mooding/e2e/E2EClient.java
@@ -48,4 +48,17 @@ public class E2EClient {
                           .log().all()
                           .extract();
     }
+
+    public static ExtractableResponse<Response> 피드백_결과_요청(final String sessionId,
+                                                            final Long id) {
+        return RestAssured.given()
+                          .sessionId(sessionId)
+                          .contentType(MediaType.APPLICATION_JSON_VALUE)
+                          .log().all()
+                          .when()
+                          .get("/feedback/{id}", id)
+                          .then()
+                          .log().all()
+                          .extract();
+    }
 }

--- a/src/test/java/com/likelion/mooding/feedback/presentation/FeedbackControllerTest.java
+++ b/src/test/java/com/likelion/mooding/feedback/presentation/FeedbackControllerTest.java
@@ -1,6 +1,7 @@
 package com.likelion.mooding.feedback.presentation;
 
 import static com.likelion.mooding.e2e.E2EClient.세션_요청;
+import static com.likelion.mooding.e2e.E2EClient.피드백_결과_요청;
 import static com.likelion.mooding.e2e.E2EClient.피드백_생성_요청;
 import static com.likelion.mooding.e2e.E2EClient.피드백_진행상태_요청;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,6 +11,7 @@ import static org.mockito.BDDMockito.given;
 import com.likelion.mooding.feedback.application.FeedbackChatCompletionService;
 import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
 import com.likelion.mooding.feedback.presentation.dto.FeedbackCreateRequest;
+import com.likelion.mooding.feedback.presentation.dto.FeedbackResultResponse;
 import com.likelion.mooding.feedback.presentation.dto.FeedbackStatusResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -29,7 +31,9 @@ import reactor.core.publisher.Mono;
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class FeedbackControllerTest {
+public class FeedbackControllerTest {
+
+    public static final int DURATION_FOR_MONO = 2000;
 
     @MockBean
     private FeedbackChatCompletionService feedbackChatCompletionService;
@@ -46,7 +50,8 @@ class FeedbackControllerTest {
     @BeforeEach
     void mockFeedbackChatCompletionService() {
         given(feedbackChatCompletionService.completeChat(any()))
-                .willReturn(Mono.just(new FeedbackCreateResponse("TEST_FEEDBACK")).delayElement(Duration.ofSeconds(2)));
+                .willReturn(Mono.just(new FeedbackCreateResponse("TEST_FEEDBACK")).delayElement(
+                        Duration.ofSeconds(DURATION_FOR_MONO / 1000)));
     }
 
     @Test
@@ -97,7 +102,7 @@ class FeedbackControllerTest {
             final ExtractableResponse<Response> feedbackResponse = 피드백_생성_요청(sessionResponse.sessionId(), request);
             final Long id = getIdFromLocationHeader(feedbackResponse.header("Location"));
 
-            Thread.sleep(2500);
+            Thread.sleep(DURATION_FOR_MONO + 500);
 
             // when
             final ExtractableResponse<Response> statusResponse = 피드백_진행상태_요청(sessionResponse.sessionId(), id);
@@ -106,6 +111,26 @@ class FeedbackControllerTest {
             final FeedbackStatusResponse actual = statusResponse.as(FeedbackStatusResponse.class);
             assertThat(actual.status()).isEqualTo("DONE");
         }
+    }
+
+    @Test
+    void 사용자가_생성된_피드백을_요청했을_때_피드백을_응답한다() throws InterruptedException {
+        // given
+        final ExtractableResponse<Response> sessionResponse = 세션_요청();
+
+        FeedbackCreateRequest request = new FeedbackCreateRequest("TEST_CONTENT");
+
+        final ExtractableResponse<Response> feedbackResponse = 피드백_생성_요청(sessionResponse.sessionId(), request);
+        final Long id = getIdFromLocationHeader(feedbackResponse.header("Location"));
+
+        Thread.sleep(DURATION_FOR_MONO + 500);
+
+        // when
+        final ExtractableResponse<Response> feedbackResultResponse = 피드백_결과_요청(sessionResponse.sessionId(), id);
+
+        // then
+        final FeedbackResultResponse resultResponse = feedbackResultResponse.as(FeedbackResultResponse.class);
+        assertThat(resultResponse.result()).isEqualTo("TEST_FEEDBACK");
     }
 
     private Long getIdFromLocationHeader(final String location) {


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #11

## 🛠️작업 내용
- DB에 저장된 피드백을 가져와 사용자에게 응답하는 API 구현

## 🤷‍♂️PR이 필요한 이유
- GPT가 생성한 피드백을 최종적으로 사용자에게 응답함으로써 사용자가 전달한 감정일기의 답장을 확인할 수 있습니다.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
