### PR TITLE
fix: 피드백 길이 변경

### DIFF
--- a/src/main/java/com/likelion/mooding/feedback/domain/Feedback.java
+++ b/src/main/java/com/likelion/mooding/feedback/domain/Feedback.java
@@ -1,6 +1,7 @@
 package com.likelion.mooding.feedback.domain;
 
 import com.likelion.mooding.auth.presentation.dto.Guest;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -19,6 +20,7 @@ public class Feedback {
     @Enumerated(value = EnumType.STRING)
     private FeedbackStatus feedbackStatus;
 
+    @Column(length = 1500)
     private String content;
 
     @Embedded


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #20 

## 🛠️작업 내용
- GPT가 생성한 피드백이 담기는 문자열의 길이를 한글 500자까지 저장할 수 있도록 수정하였습니다.

## 🤷‍♂️PR이 필요한 이유
- 기본이 VARCHAR(255)로 되어 있어서 분량이 긴 피드백을 저장하지 못해 에러가 발생하였기에 비즈니스 로직에 큰 영향을 주게 됩니다.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
