### PR TITLE
fix: 3000포트 요청에 대한 CORS 허용

### DIFF
--- a/src/main/java/com/likelion/mooding/common/config/WebConfig.java
+++ b/src/main/java/com/likelion/mooding/common/config/WebConfig.java
@@ -5,6 +5,7 @@ import com.likelion.mooding.auth.presentation.interceptor.GuestInterceptor;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -20,5 +21,16 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(new GuestInterceptor())
                 .addPathPatterns("/feedback/**");
+    }
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "OPTIONS")
+                .allowedHeaders("*")
+                .exposedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 }


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #26 

## 🛠️작업 내용
- `localhost:3000` Origin 요청에 대한 CORS 허용

## 🤷‍♂️PR이 필요한 이유
- 리액트 서버에서 백엔드 API로 요청할 경우, 브라우저 단에서 CORS 정책 위반으로 응답 값을 확인하지 못하는 상태였습니다. 해당 PR을 통해 문제를 해결할 수 있습니다.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
