### PR TITLE
fix: CORS Origin 추가

### DIFF
--- a/src/main/java/com/likelion/mooding/common/config/WebConfig.java
+++ b/src/main/java/com/likelion/mooding/common/config/WebConfig.java
@@ -13,10 +13,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private final String ALLOWED_ORIGIN;
+    private final String DOMAIN_NAME;
+    private final String WWW_DOMAIN_NAME;
 
-    public WebConfig(@Value("${allowed-origin}") final String ALLOWED_ORIGIN) {
-        this.ALLOWED_ORIGIN = ALLOWED_ORIGIN;
+    public WebConfig(
+            @Value("${allowed-origin.domain.url}") final String DOMAIN_NAME,
+            @Value("${allowed-origin.domain.www-url}") final String WWW_DOMAIN_NAME
+            ) {
+        this.DOMAIN_NAME = DOMAIN_NAME;
+        this.WWW_DOMAIN_NAME = WWW_DOMAIN_NAME;
     }
 
     @Override
@@ -33,7 +38,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", ALLOWED_ORIGIN)
+                .allowedOrigins("http://localhost:3000", DOMAIN_NAME, WWW_DOMAIN_NAME)
                 .allowedMethods("GET", "POST", "OPTIONS")
                 .allowedHeaders("*")
                 .exposedHeaders("*")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,4 +30,7 @@ openai:
   api:
     key: ${OPENAI_API_KEY}
 
-allowed-origin: ${ALLOWED_ORIGIN}
+allowed-origin:
+  domain:
+    url: ${DOMAIN_NAME}
+    www-url: ${WWW_DOMAIN_NAME}


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #31 

## 🛠️작업 내용
- CORS 허용할 Origin 환경변수 두 개로 분리
- `DOMAIN_NAME` : `https://mooding.site`
- `WWW_DOMAIN_NAME` : `https://www.mooding.site`

## 🤷‍♂️PR이 필요한 이유
- 클라이언트가 `mooding.site`로 HTTPS 요청을 보내기 때문에 해당 Origin을 추가하지 않으면 CORS 정책에 위반됨

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
