### PR TITLE
fix: OPTION 요청에 대해 인터셉터가 true를 반환하도록 수정

### DIFF
--- a/src/main/java/com/likelion/mooding/auth/presentation/interceptor/GuestInterceptor.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/interceptor/GuestInterceptor.java
@@ -12,6 +12,9 @@ public class GuestInterceptor implements HandlerInterceptor {
     public boolean preHandle(final HttpServletRequest request,
                              final HttpServletResponse response,
                              final Object handler) throws Exception {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
         final HttpSession httpSession = request.getSession(false);
         if (httpSession == null) { // 세션 ID가 아예 없거나 잘못된 세션 ID로 요청했을 때
             throw new SessionNotFoundException();


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #34 

## 🛠️작업 내용
- 스프링 인터셉터 구현 코드에서 request 메서드가 `OPTIONS`일 경우, 인증 로직을 수행하지 않도록 수정함.

## 🤷‍♂️PR이 필요한 이유
- `Content-Type`이 `application/json`인 경우, Preflight 요청을 보내게 되는데, 이 때 `OPTIONS` 메서드를 인터셉터가 처리하고 있어서 CORS 에러가 발생했습니다.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
