### PR TITLE
fix: CORS 설정 시, 응답 헤더 못 가져오는 문제 해결

### DIFF
--- a/src/main/java/com/likelion/mooding/common/config/WebConfig.java
+++ b/src/main/java/com/likelion/mooding/common/config/WebConfig.java
@@ -5,6 +5,7 @@ import com.likelion.mooding.auth.presentation.interceptor.GuestInterceptor;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -41,7 +42,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins("http://localhost:3000", DOMAIN_NAME, WWW_DOMAIN_NAME)
                 .allowedMethods("GET", "POST", "OPTIONS")
                 .allowedHeaders("*")
-                .exposedHeaders("*")
+                .exposedHeaders(HttpHeaders.LOCATION, HttpHeaders.COOKIE, HttpHeaders.CONTENT_TYPE)
                 .allowCredentials(true)
                 .maxAge(3600);
     }


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #36 

## 🛠️작업 내용
- CORS 설정 시, 응답 헤더 못 가져오는 문제 해결

## 🤷‍♂️PR이 필요한 이유
- 이 PR을 통해, 클라이언트 측에서 응답 헤더의 필드 값을 가져올 수 있게 됨.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
