### PR TITLE
feat: 예외 처리 고도화

### DIFF
--- a/src/main/java/com/likelion/mooding/auth/exception/AuthException.java
+++ b/src/main/java/com/likelion/mooding/auth/exception/AuthException.java
@@ -1,0 +1,18 @@
+package com.likelion.mooding.auth.exception;
+
+import com.likelion.mooding.common.exception.BaseException;
+import com.likelion.mooding.common.exception.BaseExceptionType;
+
+public class AuthException extends BaseException {
+
+    private final AuthExceptionType exceptionType;
+
+    public AuthException(final AuthExceptionType exceptionType) {
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/likelion/mooding/auth/exception/AuthExceptionType.java
+++ b/src/main/java/com/likelion/mooding/auth/exception/AuthExceptionType.java
@@ -1,0 +1,35 @@
+package com.likelion.mooding.auth.exception;
+
+import com.likelion.mooding.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum AuthExceptionType implements BaseExceptionType {
+
+    INVALID_SESSION(HttpStatus.UNAUTHORIZED, "유효하지 않은 세션 값입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+
+    private final String errorMessage;
+
+    AuthExceptionType(final HttpStatus httpStatus,
+                      final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorCode() {
+        return this.name();
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/likelion/mooding/auth/exception/SessionNotFoundException.java
+++ b/src/main/java/com/likelion/mooding/auth/exception/SessionNotFoundException.java
@@ -1,8 +1,0 @@
-package com.likelion.mooding.auth.exception;
-
-public class SessionNotFoundException extends RuntimeException {
-
-    public SessionNotFoundException() {
-        super("세션이 존재하지 않습니다.");
-    }
-}

--- a/src/main/java/com/likelion/mooding/auth/exception/SessionTimeoutException.java
+++ b/src/main/java/com/likelion/mooding/auth/exception/SessionTimeoutException.java
@@ -1,8 +1,0 @@
-package com.likelion.mooding.auth.exception;
-
-public class SessionTimeoutException extends RuntimeException {
-
-    public SessionTimeoutException() {
-        super("세션이 만료되었습니다.");
-    }
-}

--- a/src/main/java/com/likelion/mooding/auth/presentation/argumentresolver/GuestArgumentResolver.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/argumentresolver/GuestArgumentResolver.java
@@ -1,7 +1,8 @@
 package com.likelion.mooding.auth.presentation.argumentresolver;
 
 import com.likelion.mooding.auth.annotation.Auth;
-import com.likelion.mooding.auth.exception.SessionTimeoutException;
+import com.likelion.mooding.auth.exception.AuthException;
+import com.likelion.mooding.auth.exception.AuthExceptionType;
 import com.likelion.mooding.auth.presentation.dto.Guest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -15,7 +16,8 @@ public class GuestArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(Auth.class) && parameter.getParameterType().equals(Guest.class);
+        return parameter.hasParameterAnnotation(Auth.class) && parameter.getParameterType()
+                                                                        .equals(Guest.class);
     }
 
     @Override
@@ -29,7 +31,7 @@ public class GuestArgumentResolver implements HandlerMethodArgumentResolver {
         final HttpSession session = request.getSession(false);
 
         if (session == null) {
-            throw new SessionTimeoutException();
+            throw new AuthException(AuthExceptionType.INVALID_SESSION);
         }
 
         final String uuid = session.getAttribute("guestId").toString();

--- a/src/main/java/com/likelion/mooding/auth/presentation/dto/Guest.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/dto/Guest.java
@@ -1,7 +1,6 @@
 package com.likelion.mooding.auth.presentation.dto;
 
 import jakarta.persistence.Embeddable;
-import java.util.Objects;
 
 @Embeddable
 public record Guest(String guestId) {

--- a/src/main/java/com/likelion/mooding/auth/presentation/interceptor/GuestInterceptor.java
+++ b/src/main/java/com/likelion/mooding/auth/presentation/interceptor/GuestInterceptor.java
@@ -1,6 +1,7 @@
 package com.likelion.mooding.auth.presentation.interceptor;
 
-import com.likelion.mooding.auth.exception.SessionNotFoundException;
+import com.likelion.mooding.auth.exception.AuthException;
+import com.likelion.mooding.auth.exception.AuthExceptionType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -16,8 +17,8 @@ public class GuestInterceptor implements HandlerInterceptor {
             return true;
         }
         final HttpSession httpSession = request.getSession(false);
-        if (httpSession == null) { // 세션 ID가 아예 없거나 잘못된 세션 ID로 요청했을 때
-            throw new SessionNotFoundException();
+        if (httpSession == null) {
+            throw new AuthException(AuthExceptionType.INVALID_SESSION);
         }
         return true;
     }

--- a/src/main/java/com/likelion/mooding/common/config/WebConfig.java
+++ b/src/main/java/com/likelion/mooding/common/config/WebConfig.java
@@ -20,7 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
     public WebConfig(
             @Value("${allowed-origin.domain.url}") final String DOMAIN_NAME,
             @Value("${allowed-origin.domain.www-url}") final String WWW_DOMAIN_NAME
-            ) {
+    ) {
         this.DOMAIN_NAME = DOMAIN_NAME;
         this.WWW_DOMAIN_NAME = WWW_DOMAIN_NAME;
     }

--- a/src/main/java/com/likelion/mooding/common/exception/BaseException.java
+++ b/src/main/java/com/likelion/mooding/common/exception/BaseException.java
@@ -1,0 +1,6 @@
+package com.likelion.mooding.common.exception;
+
+public abstract class BaseException extends RuntimeException {
+
+    public abstract BaseExceptionType exceptionType();
+}

--- a/src/main/java/com/likelion/mooding/common/exception/BaseExceptionType.java
+++ b/src/main/java/com/likelion/mooding/common/exception/BaseExceptionType.java
@@ -1,0 +1,12 @@
+package com.likelion.mooding.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseExceptionType {
+
+    HttpStatus httpStatus();
+
+    String errorCode();
+
+    String errorMessage();
+}

--- a/src/main/java/com/likelion/mooding/common/exception/CommonException.java
+++ b/src/main/java/com/likelion/mooding/common/exception/CommonException.java
@@ -1,0 +1,15 @@
+package com.likelion.mooding.common.exception;
+
+public class CommonException extends BaseException {
+
+    private final CommonExceptionType exceptionType;
+
+    public CommonException(final CommonExceptionType exceptionType) {
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/likelion/mooding/common/exception/CommonExceptionType.java
+++ b/src/main/java/com/likelion/mooding/common/exception/CommonExceptionType.java
@@ -1,0 +1,33 @@
+package com.likelion.mooding.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum CommonExceptionType implements BaseExceptionType {
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+
+    private final String errorMessage;
+
+    CommonExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorCode() {
+        return this.name();
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/likelion/mooding/common/exception/ExceptionResponse.java
+++ b/src/main/java/com/likelion/mooding/common/exception/ExceptionResponse.java
@@ -1,5 +1,8 @@
 package com.likelion.mooding.common.exception;
 
-public record ExceptionResponse(String message) {
-
+public record ExceptionResponse(
+        int HttpStatusCode,
+        String errorCode,
+        String errorMessage
+) {
 }

--- a/src/main/java/com/likelion/mooding/feedback/application/FeedbackChatCompletionService.java
+++ b/src/main/java/com/likelion/mooding/feedback/application/FeedbackChatCompletionService.java
@@ -1,7 +1,7 @@
 package com.likelion.mooding.feedback.application;
 
-import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
 import com.likelion.mooding.feedback.application.dto.FeedbackCreateRequest;
+import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
 import reactor.core.publisher.Mono;
 
 public interface FeedbackChatCompletionService {

--- a/src/main/java/com/likelion/mooding/feedback/application/dto/FeedbackStatusResponse.java
+++ b/src/main/java/com/likelion/mooding/feedback/application/dto/FeedbackStatusResponse.java
@@ -1,4 +1,4 @@
 package com.likelion.mooding.feedback.application.dto;
 
-public record FeedbackStatusResponse (String status) {
+public record FeedbackStatusResponse(String status) {
 }

--- a/src/main/java/com/likelion/mooding/feedback/domain/FeedbackRepository.java
+++ b/src/main/java/com/likelion/mooding/feedback/domain/FeedbackRepository.java
@@ -14,5 +14,6 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     @Transactional
     @Modifying
     @Query("UPDATE Feedback f SET f.feedbackStatus = :feedbackStatus, f.content = :content WHERE f.id = :id")
-    void updateFeedbackStatusAndContentById(final Long id, final FeedbackStatus feedbackStatus, final String content);
+    void updateFeedbackStatusAndContentById(final Long id, final FeedbackStatus feedbackStatus,
+                                            final String content);
 }

--- a/src/main/java/com/likelion/mooding/feedback/exception/FeedbackAuthException.java
+++ b/src/main/java/com/likelion/mooding/feedback/exception/FeedbackAuthException.java
@@ -1,8 +1,0 @@
-package com.likelion.mooding.feedback.exception;
-
-public class FeedbackAuthException extends RuntimeException {
-
-    public FeedbackAuthException() {
-        super("Feedback auth failed");
-    }
-}

--- a/src/main/java/com/likelion/mooding/feedback/exception/FeedbackException.java
+++ b/src/main/java/com/likelion/mooding/feedback/exception/FeedbackException.java
@@ -1,0 +1,18 @@
+package com.likelion.mooding.feedback.exception;
+
+import com.likelion.mooding.common.exception.BaseException;
+import com.likelion.mooding.common.exception.BaseExceptionType;
+
+public class FeedbackException extends BaseException {
+
+    private final FeedbackExceptionType exceptionType;
+
+    public FeedbackException(final FeedbackExceptionType exceptionType) {
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/likelion/mooding/feedback/exception/FeedbackExceptionType.java
+++ b/src/main/java/com/likelion/mooding/feedback/exception/FeedbackExceptionType.java
@@ -1,0 +1,35 @@
+package com.likelion.mooding.feedback.exception;
+
+import com.likelion.mooding.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum FeedbackExceptionType implements BaseExceptionType {
+
+    NOT_FOUND_FEEDBACK(HttpStatus.NOT_FOUND, "피드백이 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+
+    private final String errorMessage;
+
+    FeedbackExceptionType(final HttpStatus httpStatus,
+                          final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorCode() {
+        return this.name();
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/likelion/mooding/feedback/exception/FeedbackNotFoundException.java
+++ b/src/main/java/com/likelion/mooding/feedback/exception/FeedbackNotFoundException.java
@@ -1,8 +1,0 @@
-package com.likelion.mooding.feedback.exception;
-
-public class FeedbackNotFoundException extends RuntimeException {
-
-    public FeedbackNotFoundException() {
-        super("Feedback not found");
-    }
-}

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/application/OpenAIFeedbackChatCompletionService.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/application/OpenAIFeedbackChatCompletionService.java
@@ -1,8 +1,8 @@
 package com.likelion.mooding.infrastructure.openai.application;
 
 import com.likelion.mooding.feedback.application.FeedbackChatCompletionService;
-import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
 import com.likelion.mooding.feedback.application.dto.FeedbackCreateRequest;
+import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
 import com.likelion.mooding.infrastructure.openai.dto.ChatCompletionCreateRequest;
 import com.likelion.mooding.infrastructure.openai.dto.ChatCompletionCreateResponse;
 import org.springframework.http.MediaType;
@@ -23,9 +23,12 @@ public class OpenAIFeedbackChatCompletionService implements FeedbackChatCompleti
     public Mono<FeedbackCreateResponse> completeChat(final FeedbackCreateRequest request) {
         final Mono<ChatCompletionCreateResponse> mono = webClient.post()
                                                                  .accept(MediaType.APPLICATION_JSON)
-                                                                 .bodyValue(ChatCompletionCreateRequest.from(request.diaryContent()))
+                                                                 .bodyValue(
+                                                                         ChatCompletionCreateRequest.from(
+                                                                                 request.diaryContent()))
                                                                  .retrieve()
-                                                                 .bodyToMono(ChatCompletionCreateResponse.class);
+                                                                 .bodyToMono(
+                                                                         ChatCompletionCreateResponse.class);
 
         return mono.flatMap(response -> {
             final String feedback = response.getMessageContent();

--- a/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionCreateRequest.java
+++ b/src/main/java/com/likelion/mooding/infrastructure/openai/dto/ChatCompletionCreateRequest.java
@@ -13,19 +13,19 @@ public record ChatCompletionCreateRequest(
                 "gpt-4o-mini",
                 List.of(
                         new ChatCompletionMessage(ChatCompletionRole.SYSTEM.getRole(),
-                                                  "You're a character that eats and digests the user's emotional diary, so you need to empathise with their feelings and say something kind. Don't offer solutions, but respond in a friendly, friendly way. Your response should help relieve the user's mental stress. If they're happy, celebrate with them, and if they need a compliment, give them one. If they're sad, empathise with them and let them know that you've eaten all things of user's bad feelings and will get over it since you've eaten. You must answer in Korean."),
+                                "You're a character that eats and digests the user's emotional diary, so you need to empathise with their feelings and say something kind. Don't offer solutions, but respond in a friendly, friendly way. Your response should help relieve the user's mental stress. If they're happy, celebrate with them, and if they need a compliment, give them one. If they're sad, empathise with them and let them know that you've eaten all things of user's bad feelings and will get over it since you've eaten. You must answer in Korean."),
 
                         new ChatCompletionMessage(ChatCompletionRole.USER.getRole(),
-                                                  "오늘 OpenAI API를 연동하는 작업을 예상보다 빠르게 끝낼 수 있어서 속이 후련하고 기분이 좋았어! 중간에 에러가 발생해서 답답하고 힘들었지만 그래도 문제를 해결하게 되어서 뿌듯했어."),
+                                "오늘 OpenAI API를 연동하는 작업을 예상보다 빠르게 끝낼 수 있어서 속이 후련하고 기분이 좋았어! 중간에 에러가 발생해서 답답하고 힘들었지만 그래도 문제를 해결하게 되어서 뿌듯했어."),
                         new ChatCompletionMessage(ChatCompletionRole.ASSISTANT.getRole(),
-                                                  "와, 어려운 일이었을텐데 척척 잘 해결하셨다니 너무 대단한데요? 예상보다 빠르게 작업을 끝내고 뿌듯한 기분이 들었을 거예요. 에러로 인해 힘들었던 순간도 있었겠지만, 그런 어려움을 해결하고 나니 더욱 강해진 거죠. 다음에 더 즐거운 감정일기로 만났으면 좋겠어요!"),
+                                "와, 어려운 일이었을텐데 척척 잘 해결하셨다니 너무 대단한데요? 예상보다 빠르게 작업을 끝내고 뿌듯한 기분이 들었을 거예요. 에러로 인해 힘들었던 순간도 있었겠지만, 그런 어려움을 해결하고 나니 더욱 강해진 거죠. 다음에 더 즐거운 감정일기로 만났으면 좋겠어요!"),
                         new ChatCompletionMessage(ChatCompletionRole.USER.getRole(),
-                                                  "오늘 중간고사를 봤는데 내가 공부한 내용이 하나도 나오지 않아서 완전 망했어. 밤도 새면서 최대한 할 수 있는만큼 했는데 하늘이 날 돕지 않았나봐. 너무 짜증나고 아무것도 하기 싫어."),
+                                "오늘 중간고사를 봤는데 내가 공부한 내용이 하나도 나오지 않아서 완전 망했어. 밤도 새면서 최대한 할 수 있는만큼 했는데 하늘이 날 돕지 않았나봐. 너무 짜증나고 아무것도 하기 싫어."),
                         new ChatCompletionMessage(ChatCompletionRole.ASSISTANT.getRole(),
-                                                  "슬픔과 좌절이 느껴지는데, 그런 기분 이해해요. 중간고사가 마음대로 되지 않아서 분명 실망스러웠을 거예요. 그렇지만 이렇게 힘들었던 하루를 잘 이겨내고 있다니 정말 대단해요. 시험 성적이 잘 나오지 않은 것 같아서 너무 속상하겠지만, 이 모든 감정들을 제가 다 먹어버렸어요. 그러니 곧 괜찮아질 거예요. 마음이 편해지길 바래요. 함께 이겨내요!"),
+                                "슬픔과 좌절이 느껴지는데, 그런 기분 이해해요. 중간고사가 마음대로 되지 않아서 분명 실망스러웠을 거예요. 그렇지만 이렇게 힘들었던 하루를 잘 이겨내고 있다니 정말 대단해요. 시험 성적이 잘 나오지 않은 것 같아서 너무 속상하겠지만, 이 모든 감정들을 제가 다 먹어버렸어요. 그러니 곧 괜찮아질 거예요. 마음이 편해지길 바래요. 함께 이겨내요!"),
 
                         new ChatCompletionMessage(ChatCompletionRole.USER.getRole(), userContent)
-                       )
+                )
         );
     }
 }

--- a/src/test/java/com/likelion/mooding/feedback/application/FeedbackServiceTest.java
+++ b/src/test/java/com/likelion/mooding/feedback/application/FeedbackServiceTest.java
@@ -10,9 +10,9 @@ import com.likelion.mooding.feedback.application.dto.FeedbackCreateResponse;
 import com.likelion.mooding.feedback.domain.Feedback;
 import com.likelion.mooding.feedback.domain.FeedbackRepository;
 import com.likelion.mooding.feedback.domain.FeedbackStatus;
-import com.likelion.mooding.feedback.exception.FeedbackAuthException;
 import com.likelion.mooding.feedback.application.dto.FeedbackCreateRequest;
 import com.likelion.mooding.feedback.application.dto.FeedbackStatusResponse;
+import com.likelion.mooding.feedback.exception.FeedbackException;
 import java.time.Duration;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -97,7 +97,7 @@ class FeedbackServiceTest {
             // when & then
             assertThatThrownBy(
                     () -> feedbackService.getFeedbackStatus(new Guest(otherId), feedback.getId()))
-                    .isInstanceOf(FeedbackAuthException.class);
+                    .isInstanceOf(FeedbackException.class);
         }
     }
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -29,3 +29,8 @@ logging:
 openai:
   api:
     key: 'fake-key'
+
+allowed-origin:
+  domain:
+    url: 'fake-domain'
+    www-url: 'fake-www-domain'


### PR DESCRIPTION
## 🔧연결된 이슈
- closed #16 

## 🛠️작업 내용
- 각 도메인에서 발생할 수 있는 에러 상황을 정의하고, `HTTP 상태코드, 에러 코드, 에러 메시지`를 추가하였습니다.
- `Enum`을 사용하여 도메인별 예외의 관리 포인트를 줄였습니다.

## 🤷‍♂️PR이 필요한 이유
- 예외 처리를 고도화함으로써 상황에 맞게 에러 코드를 내려줄 수 있습니다.
- 프론트엔드 개발자분들께서 상태코드 이외에 추가적인 정보를 확인할 수 있습니다.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
